### PR TITLE
Update php version for D8

### DIFF
--- a/objective_forms.info.yml
+++ b/objective_forms.info.yml
@@ -5,5 +5,5 @@ dependencies:
   - encryption:encryption
 package: 'Islandora Dependencies'
 core: 8.x
-php: '5.5.9'
+php: '7.2'
 type: module


### PR DESCRIPTION
php 5 support is being dropped:
[Drupal docs](https://www.drupal.org/docs/8/system-requirements/php-requirements)